### PR TITLE
Use class name aliasing to resolve 'Class already defined' errors

### DIFF
--- a/src/Account/CompanyClient.php
+++ b/src/Account/CompanyClient.php
@@ -3,9 +3,9 @@
 namespace UKFast\SDK\Account;
 
 use UKFast\SDK\Account\Entities\Company;
-use UKFast\SDK\Client;
+use UKFast\SDK\Client as BaseClient;
 
-class CompanyClient extends Client
+class CompanyClient extends BaseClient
 {
     protected $basePath = 'account/';
 

--- a/src/Account/ContactClient.php
+++ b/src/Account/ContactClient.php
@@ -3,11 +3,11 @@
 namespace UKFast\SDK\Account;
 
 use UKFast\SDK\Account\Entities\Contact;
-use UKFast\SDK\Client;
+use UKFast\SDK\Client as BaseClient;
 use UKFast\SDK\Page;
 use UKFast\SDK\SelfResponse;
 
-class ContactClient extends Client
+class ContactClient extends BaseClient
 {
     protected $basePath = 'account/';
     

--- a/src/Account/CreditClient.php
+++ b/src/Account/CreditClient.php
@@ -2,10 +2,10 @@
 
 namespace UKFast\SDK\Account;
 
-use UKFast\SDK\Client;
+use UKFast\SDK\Client as BaseClient;
 use UKFast\SDK\Account\Entities\Credit;
 
-class CreditClient extends Client
+class CreditClient extends BaseClient
 {
     protected $basePath = 'account/';
 


### PR DESCRIPTION
When attempting to use class `Admin\Accounts\AdminContactClient` in UKFast which extends the `SDK\Accounts\ContactClient` in this package. The following error occurs: 
   
Cannot use UKFast\SDK\Client as Client because the name is already in use
   
In this MR, I use class aliasing to change the name used to extend the `SDK\Client` class. This is done in all other SDK client classes which are extended by Admin client classes. It also solves the above error.
 

